### PR TITLE
Make more transport agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,7 +2630,6 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "tokio-serial",
  "tracing",
  "winnow 0.6.5",
 ]

--- a/print3rs-commands/src/commands.rs
+++ b/print3rs-commands/src/commands.rs
@@ -244,11 +244,11 @@ impl<S> Connection<S> {
             Connection::Auto => Connection::Auto,
             Connection::Serial { port, baud } => Connection::Serial {
                 port: port.borrow(),
-                baud: baud.clone(),
+                baud: *baud,
             },
             Connection::Tcp { hostname, port } => Connection::Tcp {
                 hostname: hostname.borrow(),
-                port: port.clone(),
+                port: *port,
             },
             Connection::Mqtt {
                 hostname,
@@ -257,9 +257,9 @@ impl<S> Connection<S> {
                 out_topic,
             } => Connection::Mqtt {
                 hostname: hostname.borrow(),
-                port: port.clone(),
-                in_topic: in_topic.map(|s| s.borrow()),
-                out_topic: out_topic.map(|s| s.borrow()),
+                port: *port,
+                in_topic: in_topic.as_ref().map(|s| s.borrow()),
+                out_topic: out_topic.as_ref().map(|s| s.borrow()),
             },
         }
     }
@@ -303,7 +303,7 @@ fn parse_mqtt_connection<'a>(input: &mut &'a str) -> PResult<Connection<&'a str>
 }
 
 fn parse_connection<'a>(input: &mut &'a str) -> PResult<Command<&'a str>> {
-    let connection = dispatch! { preceded(space0, alpha1);
+    let connection = dispatch! { preceded(space0, alpha0);
         "serial" => parse_serial_connection,
         "tcp" | "ip" => parse_tcp_connection,
         "mqtt" => parse_mqtt_connection,

--- a/print3rs-core/Cargo.toml
+++ b/print3rs-core/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.76"
 serde = "1.0.195"
 tracing = "0.1.40"
 winnow = "0.6"
-tokio-serial = { version = "5.4.4" }
 tokio = { version = "1.35.1", features = ["rt", "io-util", "sync", "macros"] }
 bytes = "1.5.0"
 thiserror = "1.0.56"

--- a/print3rs-core/src/lib.rs
+++ b/print3rs-core/src/lib.rs
@@ -294,3 +294,12 @@ impl Printer {
         self.socket().ok_or(Error::Disconnected)?.subscribe_lines()
     }
 }
+
+impl From<Option<Printer>> for Printer {
+    fn from(value: Option<Printer>) -> Self {
+        match value {
+            Some(printer) => printer,
+            None => Printer::Disconnected,
+        }
+    }
+}

--- a/print3rs-core/src/lib.rs
+++ b/print3rs-core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::{fmt::Debug, sync::Arc};
 
 use serde::Serialize;
 use winnow::Parser;
@@ -11,60 +11,17 @@ pub use response::Response;
 use print3rs_serializer::{serialize_unsequenced, Sequenced};
 
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt},
     sync::{broadcast, mpsc},
     task::JoinHandle,
 };
 
-use sealed::sealed;
-
-use bytes::{Bytes, BytesMut};
-
-pub type LineStream = broadcast::Receiver<Bytes>;
-
-#[sealed]
-#[allow(async_fn_in_trait)]
-pub trait AsyncPrinterComm {
-    /// Serialize a struct implementing Serialize and send the bytes to the printer
-    ///
-    /// Sent bytes will include a sequence number and checksum.
-    /// For printers which support advanced OK messages this will allow TCP like checked communication.
-    ///
-    /// When called, a local task is spawned to check for a matching OK message.
-    /// The handle to this task is returned after the first await on success.
-    /// This allows simple synchronization of any sent command by awaiting twice.
-    async fn send(
-        &self,
-        gcode: impl Serialize + Debug,
-    ) -> Result<tokio::task::JoinHandle<Response>, Error>;
-
-    /// Serialize anything implementing Serialize and send the bytes to the printer
-    ///
-    /// There is no guarantee that a command is correctly recieved or serviced;
-    /// any synchronization based on responses will have to be done manually.
-    ///
-    /// If your printer supports it, the sequenced `send` function is preferred,
-    /// although this version is slightly lower overhead.
-    fn send_unsequenced(&self, gcode: impl Serialize + Debug) -> Result<(), Error>;
-
-    /// Send any raw sequence of bytes to the printer
-    fn send_raw(&self, gcode: &[u8]) -> Result<(), Error>;
-
-    /// Read the next line from the printer
-    ///
-    /// May not recieve all lines, if calls to this function are spaced
-    /// far apart, the buffer may overfill and the oldest messages will
-    /// be dropped. In this case the oldest available message is returned.
-    async fn read_next_line(&mut self) -> Result<Bytes, DisconnectedError>;
-
-    /// Obtain a broadcast receiver returning all lines received by the printer
-    fn subscribe_lines(&self) -> Result<LineStream, DisconnectedError>;
-}
+pub type LineStream = broadcast::Receiver<Arc<str>>;
 
 pub async fn search_for_sequence(sequence: i32, mut responses: LineStream) -> Response {
     tracing::debug!("Started looking for Ok {sequence}");
     while let Ok(resp) = responses.recv().await {
-        match response.parse(&resp) {
+        match response.parse(resp.as_bytes()) {
             Ok(Response::SequencedOk(seq)) if seq == sequence => {
                 tracing::info!("Got Ok for line {seq}");
                 return Response::SequencedOk(seq);
@@ -83,7 +40,7 @@ pub async fn search_for_sequence(sequence: i32, mut responses: LineStream) -> Re
 pub struct Socket {
     sender: mpsc::Sender<Box<[u8]>>,
     serializer: Sequenced,
-    pub responses: broadcast::Receiver<Bytes>,
+    pub responses: broadcast::Receiver<Arc<str>>,
 }
 
 impl Clone for Socket {
@@ -96,8 +53,7 @@ impl Clone for Socket {
     }
 }
 
-#[sealed]
-impl AsyncPrinterComm for Socket {
+impl Socket {
     /// Serialize a struct implementing Serialize and send the bytes to the printer
     ///
     /// Sent bytes will include a sequence number and checksum.
@@ -107,7 +63,7 @@ impl AsyncPrinterComm for Socket {
     /// The handle to this task is returned after the first await on success.
     /// This allows simple synchronization of any sent command by awaiting twice.
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn send(
+    pub async fn send(
         &self,
         gcode: impl Serialize + Debug,
     ) -> Result<tokio::task::JoinHandle<Response>, Error> {
@@ -127,14 +83,14 @@ impl AsyncPrinterComm for Socket {
     ///
     /// If your printer supports it, the sequenced `send` function is preferred,
     /// although this version is slightly lower overhead.
-    fn send_unsequenced(&self, gcode: impl Serialize + Debug) -> Result<(), Error> {
+    pub fn send_unsequenced(&self, gcode: impl Serialize + Debug) -> Result<(), Error> {
         let bytes = serialize_unsequenced(gcode);
         self.sender.try_send(bytes)?;
         Ok(())
     }
 
     /// Send any raw sequence of bytes to the printer
-    fn send_raw(&self, gcode: &[u8]) -> Result<(), Error> {
+    pub fn send_raw(&self, gcode: &[u8]) -> Result<(), Error> {
         self.sender.try_send(gcode.to_owned().into_boxed_slice())?;
         Ok(())
     }
@@ -144,37 +100,34 @@ impl AsyncPrinterComm for Socket {
     /// May not recieve all lines, if calls to this function are spaced
     /// far apart, the buffer may overfill and the oldest messages will
     /// be dropped. In this case the oldest available message is returned.
-    async fn read_next_line(&mut self) -> Result<Bytes, DisconnectedError> {
+    pub async fn read_next_line(&mut self) -> Result<Arc<str>, Error> {
         loop {
             match self.responses.recv().await {
                 Ok(line) => break Ok(line),
                 Err(broadcast::error::RecvError::Lagged(_)) => todo!(),
-                Err(broadcast::error::RecvError::Closed) => {
-                    break Err(DisconnectedError::Disconnected)
-                }
+                Err(broadcast::error::RecvError::Closed) => break Err(Error::Disconnected),
             }
         }
     }
 
     /// Obtain a broadcast receiver returning all lines received by the printer
-    fn subscribe_lines(&self) -> Result<LineStream, DisconnectedError> {
+    pub fn subscribe_lines(&self) -> Result<LineStream, Error> {
         Ok(self.responses.resubscribe())
     }
 }
 
 /// Handle for asynchronous serial communication with a 3D printer
 #[derive(Debug, Default)]
-pub enum Printer<Transport> {
+pub enum Printer {
     #[default]
     Disconnected,
     Connected {
         socket: Socket,
         com_task: tokio::task::JoinHandle<()>,
-        _transport: PhantomData<Transport>,
     },
 }
 
-impl<S> Drop for Printer<S> {
+impl Drop for Printer {
     fn drop(&mut self) {
         if let Self::Connected { com_task, .. } = self {
             com_task.abort()
@@ -188,32 +141,26 @@ pub enum Error {
     IO(#[from] std::io::Error),
 
     #[error("Background task failed to propagate message from printer\nError message: {0}")]
-    ResponseSender(#[from] broadcast::error::SendError<Bytes>),
+    ResponseSender(#[from] broadcast::error::SendError<Arc<str>>),
 
     #[error("Send queue full or closed")]
-    Sender(#[from] tokio::sync::mpsc::error::TrySendError<std::boxed::Box<[u8]>>),
+    Sender(#[from] mpsc::error::TrySendError<Box<[u8]>>),
 
     #[error("Couldn't reserve a slot to send message")]
     SendReserve(#[from] mpsc::error::SendError<()>),
 
     #[error("Underlying printer connection was closed")]
-    Disconnected(#[from] DisconnectedError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum DisconnectedError {
-    #[error("Printer disconnected")]
     Disconnected,
 }
 
 /// Loop for handling sending/receiving in the background with possible split senders/receivers
 async fn printer_com_task(
-    mut transport: impl AsyncRead + AsyncWrite + Unpin,
+    mut transport: impl AsyncBufRead + AsyncWrite + Unpin,
     mut gcoderx: mpsc::Receiver<Box<[u8]>>,
-    responsetx: broadcast::Sender<Bytes>,
+    responsetx: broadcast::Sender<Arc<str>>,
 ) {
-    let mut buf = BytesMut::with_capacity(1024);
     tracing::debug!("Started background printer communications");
+    let mut buf = String::new();
     loop {
         tokio::select! {
             Some(line) = gcoderx.recv() => {
@@ -221,26 +168,23 @@ async fn printer_com_task(
                 if transport.flush().await.is_err() {return;}
                 tracing::debug!("Sent `{}` to printer", String::from_utf8_lossy(&line).trim());
             },
-            Ok(1..) = transport.read_buf(&mut buf) => {
-                while let Some(n) = buf.iter().position(|b| *b == b'\n') {
-                    let line = buf.split_to(n + 1).freeze();
-                    tracing::debug!("Received `{}` from printer", String::from_utf8_lossy(&line).trim());
-                    if responsetx.send(line).is_err() {return;}
-                }
+            Ok(1..) = transport.read_line(&mut buf) => {
+                tracing::debug!("Received `{buf}` from printer");
+                if responsetx.send(Arc::from(buf.split_off(0))).is_err() {return;}
             },
             else => return,
         }
     }
 }
 
-impl<S> Printer<S> {
+impl Printer {
     /// Create a new printer from a SerialStream.
     ///
     /// Starts a local task to handle printer communication asynchronously
     #[tracing::instrument(level = "debug")]
-    pub fn new(port: S) -> Self
+    pub fn new<S>(port: S) -> Self
     where
-        S: AsyncRead + AsyncWrite + Unpin + Send + 'static + Debug,
+        S: AsyncBufRead + AsyncWrite + Unpin + Send + 'static + Debug,
     {
         let (sender, gcoderx) = mpsc::channel::<Box<[u8]>>(8);
         let (response_sender, responses) = broadcast::channel(64);
@@ -253,31 +197,30 @@ impl<S> Printer<S> {
                 responses,
             },
             com_task,
-            _transport: Default::default(),
         }
     }
 
     /// Connect to a device
-    pub fn connect(&mut self, port: S)
+    pub fn connect<S>(&mut self, port: S)
     where
-        S: AsyncRead + AsyncWrite + Unpin + Send + 'static + Debug,
+        S: AsyncBufRead + AsyncWrite + Unpin + Send + 'static + Debug,
     {
         *self = Printer::new(port);
     }
 
     /// Obtain a cloneable socket handle to talk to printer
-    pub fn socket(&self) -> Result<&Socket, DisconnectedError> {
+    pub fn socket(&self) -> Option<&Socket> {
         match self {
-            Self::Disconnected => Err(DisconnectedError::Disconnected),
-            Self::Connected { socket, .. } => Ok(socket),
+            Self::Disconnected => None,
+            Self::Connected { socket, .. } => Some(socket),
         }
     }
 
     /// Obtain an exclusive socket handle - needed to read
-    pub fn socket_mut(&mut self) -> Result<&mut Socket, DisconnectedError> {
+    pub fn socket_mut(&mut self) -> Option<&mut Socket> {
         match self {
-            Self::Disconnected => Err(DisconnectedError::Disconnected),
-            Self::Connected { socket, .. } => Ok(socket),
+            Self::Disconnected => None,
+            Self::Connected { socket, .. } => Some(socket),
         }
     }
 
@@ -299,38 +242,55 @@ impl<S> Printer<S> {
             Printer::Connected { com_task, .. } => Some(com_task),
         }
     }
-}
 
-#[sealed]
-impl<S> AsyncPrinterComm for Printer<S> {
-    async fn send(
+    /// Serialize a struct implementing Serialize and send the bytes to the printer
+    ///
+    /// Sent bytes will include a sequence number and checksum.
+    /// For printers which support advanced OK messages this will allow TCP like checked communication.
+    ///
+    /// When called, a local task is spawned to check for a matching OK message.
+    /// The handle to this task is returned after the first await on success.
+    /// This allows simple synchronization of any sent command by awaiting twice.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn send(
         &self,
         gcode: impl Serialize + Debug,
     ) -> Result<tokio::task::JoinHandle<Response>, Error> {
-        let socket = self.socket()?;
-        socket.send(gcode).await
+        self.socket().ok_or(Error::Disconnected)?.send(gcode).await
     }
 
-    fn send_unsequenced(&self, gcode: impl Serialize + Debug) -> Result<(), Error> {
-        let socket = self.socket()?;
-        socket.send_unsequenced(gcode)
+    /// Serialize anything implementing Serialize and send the bytes to the printer
+    ///
+    /// There is no guarantee that a command is correctly recieved or serviced;
+    /// any synchronization based on responses will have to be done manually.
+    ///
+    /// If your printer supports it, the sequenced `send` function is preferred,
+    /// although this version is slightly lower overhead.
+    pub fn send_unsequenced(&self, gcode: impl Serialize + Debug) -> Result<(), Error> {
+        self.socket()
+            .ok_or(Error::Disconnected)?
+            .send_unsequenced(gcode)
     }
 
-    fn send_raw(&self, gcode: &[u8]) -> Result<(), Error> {
-        let socket = self.socket()?;
-        socket.send_raw(gcode)
+    /// Send any raw sequence of bytes to the printer
+    pub fn send_raw(&self, gcode: &[u8]) -> Result<(), Error> {
+        self.socket().ok_or(Error::Disconnected)?.send_raw(gcode)
     }
 
-    async fn read_next_line(&mut self) -> Result<Bytes, DisconnectedError> {
-        let socket = self.socket_mut()?;
-        socket
+    /// Read the next line from the printer
+    ///
+    /// May not recieve all lines, if calls to this function are spaced
+    /// far apart, the buffer may overfill and the oldest messages will
+    /// be dropped. In this case the oldest available message is returned.
+    pub async fn read_next_line(&mut self) -> Result<Arc<str>, Error> {
+        self.socket_mut()
+            .ok_or(Error::Disconnected)?
             .read_next_line()
             .await
-            .inspect_err(|_| self.disconnect())
     }
 
-    fn subscribe_lines(&self) -> Result<LineStream, DisconnectedError> {
-        let socket = self.socket()?;
-        socket.subscribe_lines()
+    /// Obtain a broadcast receiver returning all lines received by the printer
+    pub fn subscribe_lines(&self) -> Result<LineStream, Error> {
+        self.socket().ok_or(Error::Disconnected)?.subscribe_lines()
     }
 }

--- a/print3rs-core/src/lib.rs
+++ b/print3rs-core/src/lib.rs
@@ -7,7 +7,6 @@ mod response;
 
 use response::response;
 pub use response::Response;
-use tokio_serial::SerialStream;
 
 use print3rs_serializer::{serialize_unsequenced, Sequenced};
 
@@ -21,7 +20,6 @@ use sealed::sealed;
 
 use bytes::{Bytes, BytesMut};
 
-pub type Serial = SerialStream;
 pub type LineStream = broadcast::Receiver<Bytes>;
 
 #[sealed]
@@ -175,8 +173,6 @@ pub enum Printer<Transport> {
         _transport: PhantomData<Transport>,
     },
 }
-
-pub type SerialPrinter = Printer<Serial>;
 
 impl<S> Drop for Printer<S> {
     fn drop(&mut self) {

--- a/print3rs-host3d/src/app.rs
+++ b/print3rs-host3d/src/app.rs
@@ -1,4 +1,3 @@
-use crate::components::Console;
 use {
     crate::components,
     iced::{
@@ -10,6 +9,7 @@ use {
     print3rs_core::Printer,
     std::sync::Arc,
 };
+use {crate::components::Console, tokio_serial::SerialStream};
 
 use iced::widget::combo_box::State as ComboState;
 use iced::Command;
@@ -42,7 +42,7 @@ where
 pub(crate) struct App {
     pub(crate) ports: ComboState<String>,
     pub(crate) selected_port: Option<String>,
-    pub(crate) commander: commands::Commander,
+    pub(crate) commander: commands::Commander<SerialStream>,
     pub(crate) bauds: ComboState<u32>,
     pub(crate) selected_baud: Option<u32>,
     pub(crate) console: Console,

--- a/print3rs-host3d/src/app.rs
+++ b/print3rs-host3d/src/app.rs
@@ -1,3 +1,4 @@
+use crate::components::Console;
 use {
     crate::components,
     iced::{
@@ -9,12 +10,10 @@ use {
     print3rs_core::Printer,
     std::sync::Arc,
 };
-use {crate::components::Console, tokio_serial::SerialStream};
 
 use iced::widget::combo_box::State as ComboState;
 use iced::Command;
 
-use print3rs_core::AsyncPrinterComm;
 use tokio_serial::available_ports;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -42,7 +41,7 @@ where
 pub(crate) struct App {
     pub(crate) ports: ComboState<String>,
     pub(crate) selected_port: Option<String>,
-    pub(crate) commander: commands::Commander<SerialStream>,
+    pub(crate) commander: commands::Commander,
     pub(crate) bauds: ComboState<u32>,
     pub(crate) selected_baud: Option<u32>,
     pub(crate) console: Console,
@@ -118,15 +117,19 @@ impl iced::Application for App {
                     self.commander.set_printer(Printer::Disconnected);
                 } else if let Some(ref port) = self.selected_port {
                     if port == "auto" {
-                        if let Err(msg) = self
-                            .commander
-                            .dispatch(print3rs_commands::commands::Command::AutoConnect)
+                        if let Err(msg) =
+                            self.commander
+                                .dispatch(print3rs_commands::commands::Command::Connect(
+                                    print3rs_commands::commands::Connection::Auto,
+                                ))
                         {
                             self.error_messages.push(msg.0);
                         }
                     } else if let Err(msg) = self.commander.dispatch(commands::Command::Connect(
-                        port.as_str(),
-                        self.selected_baud,
+                        commands::Connection::Serial {
+                            port: port.as_str(),
+                            baud: self.selected_baud,
+                        },
                     )) {
                         self.error_messages.push(msg.0);
                     }

--- a/print3rs-host3d/src/messages.rs
+++ b/print3rs-host3d/src/messages.rs
@@ -1,10 +1,11 @@
 use {
     print3rs_commands::commands::{Command, Response},
-    print3rs_core::SerialPrinter,
+    print3rs_core::Printer,
     std::{
         path::PathBuf,
         sync::{Arc, Mutex},
     },
+    tokio_serial::SerialStream,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -50,7 +51,7 @@ pub(crate) enum Message {
     SaveDialog,
     SaveConsole(PathBuf),
     ConsoleAppend(String),
-    AutoConnectComplete(Arc<Mutex<SerialPrinter>>),
+    AutoConnectComplete(Arc<Mutex<Printer<SerialStream>>>),
     PushError(String),
     DismissError,
     OutputAction(iced::widget::text_editor::Action),

--- a/print3rs-host3d/src/messages.rs
+++ b/print3rs-host3d/src/messages.rs
@@ -5,7 +5,6 @@ use {
         path::PathBuf,
         sync::{Arc, Mutex},
     },
-    tokio_serial::SerialStream,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -51,7 +50,7 @@ pub(crate) enum Message {
     SaveDialog,
     SaveConsole(PathBuf),
     ConsoleAppend(String),
-    AutoConnectComplete(Arc<Mutex<Printer<SerialStream>>>),
+    AutoConnectComplete(Arc<Mutex<Printer>>),
     PushError(String),
     DismissError,
     OutputAction(iced::widget::text_editor::Action),
@@ -62,7 +61,7 @@ pub(crate) enum Message {
 impl From<Response> for Message {
     fn from(value: Response) -> Self {
         match value {
-            Response::Output(s) => Message::ConsoleAppend(s),
+            Response::Output(s) => Message::ConsoleAppend(s.to_string()),
             Response::Error(e) => Message::PushError(e.0),
             Response::AutoConnect(a) => Message::AutoConnectComplete(a),
             Response::Clear => Message::ClearConsole,

--- a/print3rs-lin3d/src/main.rs
+++ b/print3rs-lin3d/src/main.rs
@@ -5,7 +5,6 @@
 use {
     print3rs_core::Printer,
     std::{fmt::Debug, sync::Arc},
-    tokio_serial::SerialStream,
 };
 
 use futures_util::AsyncWriteExt;
@@ -27,7 +26,7 @@ enum AppError {
     Writer(#[from] futures_util::io::Error),
 }
 
-fn prompt_string(printer: &Printer<SerialStream>) -> String {
+fn prompt_string(printer: &Printer) -> String {
     let status = match printer {
         print3rs_core::Printer::Disconnected => "Disconnected",
         print3rs_core::Printer::Connected { .. } => "Connected",

--- a/print3rs-lin3d/src/main.rs
+++ b/print3rs-lin3d/src/main.rs
@@ -2,7 +2,11 @@
 //!  A shell to talk to 3D printers or other Gcode accepting serial devices, inspired by Pronsole
 //!
 
-use {print3rs_core::SerialPrinter, std::fmt::Debug, std::sync::Arc};
+use {
+    print3rs_core::Printer,
+    std::{fmt::Debug, sync::Arc},
+    tokio_serial::SerialStream,
+};
 
 use futures_util::AsyncWriteExt;
 use rustyline_async::{Readline, ReadlineEvent, SharedWriter};
@@ -23,7 +27,7 @@ enum AppError {
     Writer(#[from] futures_util::io::Error),
 }
 
-fn prompt_string(printer: &SerialPrinter) -> String {
+fn prompt_string(printer: &Printer<SerialStream>) -> String {
     let status = match printer {
         print3rs_core::Printer::Disconnected => "Disconnected",
         print3rs_core::Printer::Connected { .. } => "Connected",


### PR DESCRIPTION
* Refactor Printer to not take a generic argument for transport. This makes the printer object able to support any generic transport mechanism without client code using generics.
* Remove `AsyncPrinterComm`  trait, not needed since Printer doesn't take a generic anymore. Printer still provides all the same methods as Socket. Socket is semantically just a weak version of Printer.
* Cut bytes dependency out of core, the printer now uses `Arc<str>` to broadcast responses.
* Change connection command, removing `AutoConnect` as a distinct command, and bundling it into `Connect`. Command now takes a "protocol" argument, e.g. `connect serial COM3 115200`.  Omitting arguments will attempt auto connection.
* Fixup lin3d and host3d to work with refactors.