### PR TITLE
Multiple in flight commands

### DIFF
--- a/print3rs-commands/src/commands.rs
+++ b/print3rs-commands/src/commands.rs
@@ -1,17 +1,15 @@
 use {
     core::borrow::Borrow,
-    futures_util::{Future, TryFutureExt},
     print3rs_core::Socket,
     std::{
         collections::HashMap,
-        default,
         fmt::Debug,
         sync::{Arc, Mutex},
         time::Duration,
     },
     tokio::io::BufReader,
     tokio_serial::SerialStream,
-    winnow::ascii::{alpha0, Caseless},
+    winnow::ascii::alpha0,
 };
 
 use winnow::{
@@ -381,32 +379,6 @@ impl<S> Command<S> {
             Unrecognized => Unrecognized,
         }
     }
-    // pub fn into_box(self) -> Command<Box<S>>
-    // where
-    //     Box<S>: From<S>,
-    // {
-    //     use Command::*;
-    //     match self {
-    //         Gcodes(codes) => Gcodes(codes.into_iter().map(|s| s.into()).collect()),
-    //         Print(filename) => Print(filename.into()),
-    //         Log(name, pattern) => Log(name.into(), pattern.into_iter().map(|s| s.into()).collect()),
-    //         Repeat(name, codes) => {
-    //             Repeat(name.into(), codes.into_iter().map(|s| s.into()).collect())
-    //         }
-    //         Tasks => Tasks,
-    //         Stop(s) => Stop(s.into()),
-    //         Connect(connection) => Connect(connection.into_owned()),
-    //         Disconnect => Disconnect,
-    //         Macro(name, codes) => Macro(name.into(), codes.into_iter().map(|s| s.into()).collect()),
-    //         Macros => Macros,
-    //         DeleteMacro(s) => DeleteMacro(s.into()),
-    //         Help(s) => Help(s.into()),
-    //         Version => Version,
-    //         Clear => Clear,
-    //         Quit => Quit,
-    //         Unrecognized => Unrecognized,
-    //     }
-    // }
 }
 
 impl<S> Command<S> {

--- a/print3rs-host3d/src/app.rs
+++ b/print3rs-host3d/src/app.rs
@@ -106,7 +106,7 @@ impl iced::Application for App {
                 if let Err(msg) = self
                     .commander
                     .printer()
-                    .send_unsequenced(format!("G7X{x}Y{y}Z{z}"))
+                    .try_send_unsequenced(format!("G7X{x}Y{y}Z{z}"))
                 {
                     self.error_messages.push(msg.to_string());
                 }

--- a/print3rs-lin3d/src/main.rs
+++ b/print3rs-lin3d/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), AppError> {
 
     writer.write_all(commands::version().as_bytes()).await?;
     writer
-        .write_all(b"\ntype `:help` for a list of commands\n")
+        .write_all(b"\ntype `help` for a list of commands\n")
         .await?;
     setup_logging(writer.clone());
 


### PR DESCRIPTION
Refactor print3rs_core to issue up to 4 commands, allowing commands to be buffered on the side of the printer for better latency.

Changed how 'ok' messages were parsed to not require multiple tasks to be spawned, instead using oneshots to communicate finished commands, with all the handling in the existing background task. 

Chaged APIs to fit refactor, in general they've become easier to use. There's now also async and sync versions of each relevant command for better flexibility. Error type has been improved to make handling these easier too.