### PR TITLE
Remove explicit send and improve gcode parsing

### DIFF
--- a/print3rs-commands/src/logging/parsing.rs
+++ b/print3rs-commands/src/logging/parsing.rs
@@ -3,9 +3,13 @@ use winnow::{
     combinator::{alt, delimited, dispatch, empty, fail, preceded, repeat, rest},
     prelude::*,
     stream::AsChar,
-    token::{take, take_till, take_until, take_while},
+    token::{take, take_till, take_until},
 };
-use {crate::commands::Command, core::borrow::Borrow, winnow::ascii::space0};
+use {
+    crate::commands::{identifier, Command},
+    core::borrow::Borrow,
+    winnow::ascii::space0,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Segment<S> {
@@ -74,10 +78,8 @@ fn parse_escape<'a>(input: &mut &'a str) -> PResult<Segment<&'a str>> {
 }
 
 fn parse_value<'a>(input: &mut &'a str) -> PResult<Segment<&'a str>> {
-    let name_chars = ('a'..='z', 'A'..='Z', '0'..='9', ['-', '_', ' ', '.']);
-    let name_chars1 = take_while(1.., name_chars);
     Ok(Segment::Value(
-        delimited("{", name_chars1, "}").parse_next(input)?,
+        delimited("{", identifier, "}").parse_next(input)?,
     ))
 }
 
@@ -91,7 +93,7 @@ pub fn parse_segments<'a>(input: &mut &'a str) -> PResult<Vec<Segment<&'a str>>>
 
 pub fn parse_logger<'a>(input: &mut &'a str) -> PResult<Command<&'a str>> {
     (
-        preceded(space0, alphanumeric1),
+        preceded(space0, identifier),
         preceded(space1, parse_segments),
     )
         .map(|(name, segments)| Command::Log(name, segments))

--- a/print3rs-lin3d/src/main.rs
+++ b/print3rs-lin3d/src/main.rs
@@ -98,7 +98,10 @@ async fn main() -> Result<(), AppError> {
                         continue;
                     }
                 };
-                let _ = commander.dispatch(command);
+                if let Err(e) = commander.dispatch(command) {
+                    writer.write_all(e.0.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
+                }
                 readline.add_history_entry(line);
             },
         }


### PR DESCRIPTION
* change gcode parsing to be smarter about identifying gcodes
* change parsers that result in tasks and macros to allow '-', '.', and '_' characters, and check that they don't look like Gcodes
* human readable error messages
* simplify error handling
* return a result for core `socket()` function instead of option, since it will give descriptive error and is very easily convertible to option.