### PR TITLE
fix dist dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,13 @@ install-path = "CARGO_HOME"
 install-updater = false
 
 [workspace.metadata.dist.dependencies.apt]
+pkg-config = "*"
 libudev-dev = "*"
+libgtk-3-dev = "*"
+libexpat1-dev = "*"
+libfontconfig-dev = "*"
+libfreetype-dev = "*"
+libxkbcommon-dev = "*"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
switching to libcosmic added some dev dependencies for linux builds, but those weren't added to cargo-dist dependencies.